### PR TITLE
Add Game code hot reloading in linux

### DIFF
--- a/src/linux_plover.cpp
+++ b/src/linux_plover.cpp
@@ -68,7 +68,7 @@ internal_func linux_GameCode linux_loadGameCode(linux_GameCode oldCode) {
 
 		if (oldCode.sharedObject) {
 			res = dlclose(oldCode.sharedObject);
-			assert(res && "Failed to unload shared object!");
+			assert((!res) && "Failed to unload shared object!");
 		}
 		newCode.sharedObject = dlopen(LINUX_GAME_SO, RTLD_LAZY);
 		if (newCode.sharedObject) {
@@ -122,7 +122,6 @@ int main() {
 
 	renderer.init();
 	while (renderer.render()) {
-		//memory.mousePosition = mousePosition;
 		game = linux_loadGameCode(game);
 		game.updateAndRender(&handles, &memory);
 		renderer.processCommands();

--- a/src/linux_plover.cpp
+++ b/src/linux_plover.cpp
@@ -8,6 +8,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <dlfcn.h>
+#include <sys/stat.h>
+
+#define LINUX_GAME_SO "../libProjectG.so"
+#define GAME_UPDATE_RENDER_FUNC "gameUpdateAndRender"
 
 // OS-Independent Wrappers
 // TODO(oliver): Handle errors instead of just asserting
@@ -39,6 +43,8 @@ void DEBUG_log(const char *f, ...) {
 
 // Shared Library Loading
 struct linux_GameCode {
+	long modificationTime;
+	void *sharedObject;
 	f_gameUpdateAndRender* updateAndRender;
 };
 
@@ -47,23 +53,40 @@ internal_func int linux_guarStub(Handles *_h, GameMemory *_gm) {
 	return 0;
 }
 
-internal_func linux_GameCode linux_loadGameCode() {
-	linux_GameCode result = {};
-	result.updateAndRender = linux_guarStub;
-	void *gameCodeSO = dlopen("../libProjectG.so", RTLD_LAZY);
-	if (gameCodeSO) {
-		result.updateAndRender = (f_gameUpdateAndRender*) dlsym(gameCodeSO, "gameUpdateAndRender");
-		if (!result.updateAndRender) result.updateAndRender = linux_guarStub;
-	}
+internal_func linux_GameCode linux_loadGameCode(linux_GameCode oldCode) {
+	int res;
 
-	return result;
+	struct stat dlStat = {};
+	res = stat(LINUX_GAME_SO, &dlStat);
+	assert(res && "Failed to get shared library attributes!");
+
+	if (dlStat.st_mtim.tv_nsec != oldCode.modificationTime) {
+		linux_GameCode newCode = {};
+		newCode.modificationTime = dlStat.st_mtim.tv_nsec;
+		newCode.updateAndRender = linux_guarStub;
+
+		if (oldCode.sharedObject) {
+			res = dlclose(oldCode.sharedObject);
+			assert(res && "Failed to unload shared object!");
+		}
+		newCode.sharedObject = dlopen(LINUX_GAME_SO, RTLD_LAZY);
+		if (newCode.sharedObject) {
+			newCode.updateAndRender = (f_gameUpdateAndRender *) dlsym(newCode.sharedObject, GAME_UPDATE_RENDER_FUNC);
+
+			if (!newCode.updateAndRender) {
+				newCode.updateAndRender = linux_guarStub;
+			}
+		}
+		return newCode;
+	}
+	return oldCode;
 }
 
 // Handles
 internal_func Handles linux_createHandles() {
 	Handles handles{};
 	handles.DEBUG_log = DEBUG_log;
-	handles.isKeyDown = isKeyDown;
+	//handles.isKeyDown = isKeyDown;
 	handles.pushRenderCommand = pushRenderCommand;
 	handles.hasRenderMessage = hasRenderMessage;
 	handles.popRenderMessage = popRenderMessage;
@@ -85,7 +108,8 @@ internal_func void linux_destroyMemory(GameMemory memory) {
 }
 
 int main() {
-	linux_GameCode game = linux_loadGameCode();
+	linux_GameCode game {};
+	game = linux_loadGameCode(game);
 	Handles handles = linux_createHandles();
 	GameMemory memory = linux_createMemory();
 
@@ -96,7 +120,7 @@ int main() {
 
 	renderer.init();
 	while (renderer.render()) {
-		memory.mousePosition = mousePosition;
+		//memory.mousePosition = mousePosition;
 		game.updateAndRender(&handles, &memory);
 		renderer.processCommands();
 	}

--- a/src/linux_plover.cpp
+++ b/src/linux_plover.cpp
@@ -46,6 +46,7 @@ struct linux_GameCode {
 	long modificationTime;
 	void *sharedObject;
 	f_gameUpdateAndRender* updateAndRender;
+
 };
 
 internal_func int linux_guarStub(Handles *_h, GameMemory *_gm) {
@@ -58,7 +59,7 @@ internal_func linux_GameCode linux_loadGameCode(linux_GameCode oldCode) {
 
 	struct stat dlStat = {};
 	res = stat(LINUX_GAME_SO, &dlStat);
-	assert(res && "Failed to get shared library attributes!");
+	assert((!res) && "Failed to get shared library attributes!");
 
 	if (dlStat.st_mtim.tv_nsec != oldCode.modificationTime) {
 		linux_GameCode newCode = {};

--- a/src/linux_plover.cpp
+++ b/src/linux_plover.cpp
@@ -123,6 +123,7 @@ int main() {
 	renderer.init();
 	while (renderer.render()) {
 		//memory.mousePosition = mousePosition;
+		game = linux_loadGameCode(game);
 		game.updateAndRender(&handles, &memory);
 		renderer.processCommands();
 	}

--- a/src/linux_plover.cpp
+++ b/src/linux_plover.cpp
@@ -87,7 +87,8 @@ internal_func linux_GameCode linux_loadGameCode(linux_GameCode oldCode) {
 internal_func Handles linux_createHandles() {
 	Handles handles{};
 	handles.DEBUG_log = DEBUG_log;
-	//handles.isKeyDown = isKeyDown;
+	handles.getTime = getTime;
+	handles.getInputMessage = getInputMessage;
 	handles.pushRenderCommand = pushRenderCommand;
 	handles.hasRenderMessage = hasRenderMessage;
 	handles.popRenderMessage = popRenderMessage;


### PR DESCRIPTION
This push implements the game code hot reloading feature, present in the windows platform layer, into the linux layer.  Hot reloading calls the loadGameCode function on every update, but only reloads the game code if it has been modified since last loaded.

Tested on:

- [X] A Linux Machine - game runs, loading works.